### PR TITLE
Fix encoding of byte array attribute

### DIFF
--- a/p11kit/p11kit.go
+++ b/p11kit/p11kit.go
@@ -22,7 +22,7 @@
 // Clients configure an environment variable, then dlopen the p11-kit-client.so
 // PKCS #11 shared library to communicate with the remote.
 //
-//     P11_KIT_SERVER_ADDRESS=unix:path=/run/user/12345/p11-kit/pkcs11-12345
+//	P11_KIT_SERVER_ADDRESS=unix:path=/run/user/12345/p11-kit/pkcs11-12345
 //
 // Normally the remote is served by the "p11-kit server ..." command.
 //
@@ -30,46 +30,45 @@
 // program to act as a PKCS #11 module. Users can load keys and certificates,
 // then listen on a unix socket to handle requests from p11-kit-client.so.
 //
-//     privObj, err := p11kit.NewPrivateKeyObject(priv)
-//     if err != nil {
-//         // ...
-//     }
-//     certObj, err := p11kit.NewX509CertificateObject(cert)
-//     if err != nil {
-//         // ...
-//     }
+//	privObj, err := p11kit.NewPrivateKeyObject(priv)
+//	if err != nil {
+//	    // ...
+//	}
+//	certObj, err := p11kit.NewX509CertificateObject(cert)
+//	if err != nil {
+//	    // ...
+//	}
 //
-//     slot := p11kit.Slot{
-//         ID:      0x01,
-//         Objects: []p11kit.Object{privObj, certObj},
-//         // Additional fields...
-//     }
+//	slot := p11kit.Slot{
+//	    ID:      0x01,
+//	    Objects: []p11kit.Object{privObj, certObj},
+//	    // Additional fields...
+//	}
 //
-//     h := p11kit.Handler{
-//         Manufacturer:   "example",
-//         Library:        "example",
-//         LibraryVersion: p11kit.Version{Major: 0, Minor: 1},
-//         Slots:          []p11kit.Slot{slot},
-//     }
+//	h := p11kit.Handler{
+//	    Manufacturer:   "example",
+//	    Library:        "example",
+//	    LibraryVersion: p11kit.Version{Major: 0, Minor: 1},
+//	    Slots:          []p11kit.Slot{slot},
+//	}
 //
-//     l, err := net.Listen("unix", "/run/user/12345/p11-kit/pkcs11-12345")
-//     if err != nil {
-//         // ...
-//     }
-//     defer l.Close()
-//     for {
-//         conn, err := l.Accept()
-//         if err != nil {
-//             // ...
-//         }
-//         go func() {
-//             if err := h.Handle(conn); err != nil {
-//                 log.Println(err)
-//             }
-//             conn.Close()
-//         }()
-//     }
-//
+//	l, err := net.Listen("unix", "/run/user/12345/p11-kit/pkcs11-12345")
+//	if err != nil {
+//	    // ...
+//	}
+//	defer l.Close()
+//	for {
+//	    conn, err := l.Accept()
+//	    if err != nil {
+//	        // ...
+//	    }
+//	    go func() {
+//	        if err := h.Handle(conn); err != nil {
+//	            log.Println(err)
+//	        }
+//	        conn.Close()
+//	    }()
+//	}
 package p11kit
 
 import (

--- a/p11kit/rpc.go
+++ b/p11kit/rpc.go
@@ -197,6 +197,10 @@ func newBuffer(b []byte) buffer {
 }
 
 // https://github.com/p11-glue/p11-kit/blob/0.24.0/p11-kit/rpc-message.c#L1039
+// https://github.com/p11-glue/p11-kit/blob/0.24.0/p11-kit/rpc-message.c#L1024
+// https://github.com/p11-glue/p11-kit/blob/0.24.0/p11-kit/rpc-message.c#L730
+// https://github.com/p11-glue/p11-kit/blob/0.24.0/common/buffer.c#L186
+// https://github.com/p11-glue/p11-kit/issues/679
 func (b *buffer) addAttribute(a attribute) {
 	b.addUint32(uint32(a.typ))
 	val := a.value()
@@ -204,8 +208,16 @@ func (b *buffer) addAttribute(a attribute) {
 		b.addByte(0)
 		return
 	}
+	// An attribute is encoded as a byte array, but the prefix length is not the
+	// length of the full byte array "len(data) + data...", it adds the original
+	// length twice, in this case it will be "len(val) - 4" the extra 4 bytes of
+	// the length prefix in the byte array. See links above.
+	length := uint32(len(val))
+	if a.typ.valueType() == attributeTypeByteArray {
+		length -= 4
+	}
 	b.addByte(1)
-	b.addUint32(uint32(len(val)))
+	b.addUint32(length)
 	b.b = append(b.b, val...)
 }
 

--- a/p11kit/rpc_test.go
+++ b/p11kit/rpc_test.go
@@ -152,6 +152,81 @@ func TestBufferAdd(t *testing.T) {
 			},
 			[]byte("12341230" + "20210101"),
 		},
+		{
+			"addAttributeByte",
+			func(b *buffer) {
+				b.addAttribute(attribute{
+					typ:  attributeToken,
+					byte: bTrue,
+				})
+			},
+			[]byte{
+				0x00, 0x00, 0x00, 0x01,
+				0x01,
+				0x00, 0x00, 0x00, 0x01,
+				0x01,
+			},
+		},
+		{
+			"addAttributeULong",
+			func(b *buffer) {
+				objectClass := ckoCertificate
+				b.addAttribute(attribute{
+					typ:   attributeClass,
+					ulong: &objectClass,
+				})
+			},
+			[]byte{
+				0x00, 0x00, 0x00, 0x00,
+				0x01,
+				0x00, 0x00, 0x00, 0x08,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+			},
+		},
+		{
+			"addAttributeByteArray",
+			func(b *buffer) {
+				b.addAttribute(attribute{
+					typ:   attributeID,
+					bytes: []byte{0x12, 0x34, 0x56, 0x78},
+				})
+			},
+			[]byte{
+				0x00, 0x00, 0x01, 0x02,
+				0x01,
+				0x00, 0x00, 0x00, 0x04,
+				0x00, 0x00, 0x00, 0x04,
+				0x12, 0x34, 0x56, 0x78,
+			},
+		},
+		{
+			"addAttributeDate",
+			func(b *buffer) {
+				t := time.Date(1234, 12, 30, 0, 0, 0, 0, time.UTC)
+				b.addAttribute(attribute{
+					typ:  attributeStartDate,
+					date: &t,
+				})
+			},
+			[]byte{
+				0x00, 0x00, 0x01, 0x10,
+				0x01,
+				0x00, 0x00, 0x00, 0x08,
+				0x31, 0x32, 0x33, 0x34, 0x31, 0x32, 0x33, 0x30,
+			},
+		},
+		{
+			"addAttributeEmpty",
+			func(b *buffer) {
+				b.addAttribute(attribute{
+					typ: attributeWrapTemplate,
+				})
+			},
+			[]byte{
+				0x40, 0x00, 0x02, 0x11,
+				0x00,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This commit fixes the encoding of byte array attribute. According to the code of p11-kit 0.24.x the size of the full data array is just the size of the data, instead of the size of the length, 4, plus the size of the data.

This version is compatible with p11-kit 0.24.x and 0.25.x.

See that the byte array adds the length [here](https://github.com/p11-glue/p11-kit/blob/dd0590d4e583f107e3e9fafe9ed754149da335d0/p11-kit/rpc-message.c#L729-L743) and the length again and the data [here](https://github.com/p11-glue/p11-kit/blob/dd0590d4e583f107e3e9fafe9ed754149da335d0/common/buffer.c#L185-L198).
