### PR TITLE
Add CKA_SIGN_RECOVER attribute to private keys

### DIFF
--- a/example/example-p11-kit-server/main.go
+++ b/example/example-p11-kit-server/main.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/go-p11-kit/p11kit"
+	"github.com/smallstep/go-p11-kit/p11kit"
 )
 
 func usage() {

--- a/p11kit/attribute.go
+++ b/p11kit/attribute.go
@@ -384,6 +384,7 @@ func newKeyObject(pub crypto.PublicKey, isPrivate bool) ([]attribute, error) {
 			attribute{typ: attributeNeverExtractable, byte: bTrue},    // CKA_NEVER_EXTRACTABLE
 			attribute{typ: attributeAlwaysAuthenticate, byte: bFalse}, // CKA_ALWAYS_AUTHENTICATE
 			attribute{typ: attributeSign, byte: bTrue},                // CKA_SIGN
+			attribute{typ: attributeSignRecover, byte: bFalse},        // CKA_SIGN_RECOVER
 			attribute{typ: attributeUnwrap, byte: bFalse},             // CKA_UNWRAP
 		)
 	}


### PR DESCRIPTION
### Description

This commit adds the CKA_SIGN_RECOVER attribute to the private keys. With asymmetric keys you cannot recover data from signatures. Adding this attribute avoids warnings displayed by pkcs11-tool, because it asks for this attribute.